### PR TITLE
[FEAT] 파파고 API 언어 테이블뷰, 화면전환, UI 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+/Resource

--- a/NetWorkProject.xcodeproj/project.pbxproj
+++ b/NetWorkProject.xcodeproj/project.pbxproj
@@ -24,6 +24,13 @@
 		8BFD637A2B56D73C001B93C6 /* Beer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFD63792B56D73C001B93C6 /* Beer.swift */; };
 		8BFD637C2B56D9D8001B93C6 /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFD637B2B56D9D8001B93C6 /* APIManager.swift */; };
 		8BFD637F2B56F5E6001B93C6 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 8BFD637E2B56F5E6001B93C6 /* Kingfisher */; };
+		8BFD638C2B57B4CE001B93C6 /* AnyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFD638A2B57B4CE001B93C6 /* AnyTableViewCell.swift */; };
+		8BFD638D2B57B4CE001B93C6 /* AnyTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8BFD638B2B57B4CE001B93C6 /* AnyTableViewCell.xib */; };
+		8BFD63922B57B899001B93C6 /* LanguageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFD63912B57B899001B93C6 /* LanguageViewController.swift */; };
+		8BFD63942B57B8B8001B93C6 /* PapagoMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFD63932B57B8B8001B93C6 /* PapagoMainViewController.swift */; };
+		8BFD63962B57B949001B93C6 /* Papago.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFD63952B57B949001B93C6 /* Papago.swift */; };
+		8BFD63992B57CE05001B93C6 /* Enumeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFD63982B57CE05001B93C6 /* Enumeration.swift */; };
+		8BFD639E2B57D413001B93C6 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = 8BFD639D2B57D413001B93C6 /* .gitignore */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +51,13 @@
 		8BFD63772B56D1F3001B93C6 /* BeerListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeerListViewController.swift; sourceTree = "<group>"; };
 		8BFD63792B56D73C001B93C6 /* Beer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Beer.swift; sourceTree = "<group>"; };
 		8BFD637B2B56D9D8001B93C6 /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
+		8BFD638A2B57B4CE001B93C6 /* AnyTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyTableViewCell.swift; sourceTree = "<group>"; };
+		8BFD638B2B57B4CE001B93C6 /* AnyTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AnyTableViewCell.xib; sourceTree = "<group>"; };
+		8BFD63912B57B899001B93C6 /* LanguageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageViewController.swift; sourceTree = "<group>"; };
+		8BFD63932B57B8B8001B93C6 /* PapagoMainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PapagoMainViewController.swift; sourceTree = "<group>"; };
+		8BFD63952B57B949001B93C6 /* Papago.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Papago.swift; sourceTree = "<group>"; };
+		8BFD63982B57CE05001B93C6 /* Enumeration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enumeration.swift; sourceTree = "<group>"; };
+		8BFD639D2B57D413001B93C6 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +76,7 @@
 		8BFD63422B5673B1001B93C6 = {
 			isa = PBXGroup;
 			children = (
+				8BFD639D2B57D413001B93C6 /* .gitignore */,
 				8BFD634D2B5673B1001B93C6 /* NetWorkProject */,
 				8BFD634C2B5673B1001B93C6 /* Products */,
 			);
@@ -78,6 +93,7 @@
 		8BFD634D2B5673B1001B93C6 /* NetWorkProject */ = {
 			isa = PBXGroup;
 			children = (
+				8BFD638E2B57B853001B93C6 /* PapagoAPI */,
 				8BFD63722B56D179001B93C6 /* BeerAPI */,
 				8BFD636F2B56BBFD001B93C6 /* Extension */,
 				8BFD636C2B567B90001B93C6 /* Model */,
@@ -90,6 +106,9 @@
 				8BFD63592B5673B3001B93C6 /* LaunchScreen.storyboard */,
 				8BFD635C2B5673B3001B93C6 /* Info.plist */,
 				8BFD637B2B56D9D8001B93C6 /* APIManager.swift */,
+				8BFD638A2B57B4CE001B93C6 /* AnyTableViewCell.swift */,
+				8BFD638B2B57B4CE001B93C6 /* AnyTableViewCell.xib */,
+				8BFD63982B57CE05001B93C6 /* Enumeration.swift */,
 			);
 			path = NetWorkProject;
 			sourceTree = "<group>";
@@ -106,6 +125,7 @@
 		8BFD636C2B567B90001B93C6 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				8BFD63952B57B949001B93C6 /* Papago.swift */,
 				8BFD636D2B567B99001B93C6 /* Lotto.swift */,
 				8BFD63792B56D73C001B93C6 /* Beer.swift */,
 			);
@@ -128,6 +148,15 @@
 				8BFD63772B56D1F3001B93C6 /* BeerListViewController.swift */,
 			);
 			path = BeerAPI;
+			sourceTree = "<group>";
+		};
+		8BFD638E2B57B853001B93C6 /* PapagoAPI */ = {
+			isa = PBXGroup;
+			children = (
+				8BFD63912B57B899001B93C6 /* LanguageViewController.swift */,
+				8BFD63932B57B8B8001B93C6 /* PapagoMainViewController.swift */,
+			);
+			path = PapagoAPI;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -197,7 +226,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				8BFD63662B567702001B93C6 /* Lottery.storyboard in Resources */,
+				8BFD639E2B57D413001B93C6 /* .gitignore in Resources */,
 				8BFD63742B56D190001B93C6 /* Beer.storyboard in Resources */,
+				8BFD638D2B57B4CE001B93C6 /* AnyTableViewCell.xib in Resources */,
 				8BFD635B2B5673B3001B93C6 /* LaunchScreen.storyboard in Resources */,
 				8BFD63582B5673B3001B93C6 /* Assets.xcassets in Resources */,
 				8BFD63562B5673B1001B93C6 /* Main.storyboard in Resources */,
@@ -211,8 +242,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8BFD63942B57B8B8001B93C6 /* PapagoMainViewController.swift in Sources */,
 				8BFD636E2B567B99001B93C6 /* Lotto.swift in Sources */,
 				8BFD63642B5676FA001B93C6 /* LotteryViewController.swift in Sources */,
+				8BFD63922B57B899001B93C6 /* LanguageViewController.swift in Sources */,
 				8BFD63532B5673B1001B93C6 /* ViewController.swift in Sources */,
 				8BFD63782B56D1F3001B93C6 /* BeerListViewController.swift in Sources */,
 				8BFD637C2B56D9D8001B93C6 /* APIManager.swift in Sources */,
@@ -220,6 +253,9 @@
 				8BFD63512B5673B1001B93C6 /* SceneDelegate.swift in Sources */,
 				8BFD637A2B56D73C001B93C6 /* Beer.swift in Sources */,
 				8BFD63712B56BC08001B93C6 /* DateFormatter+Extension.swift in Sources */,
+				8BFD63992B57CE05001B93C6 /* Enumeration.swift in Sources */,
+				8BFD63962B57B949001B93C6 /* Papago.swift in Sources */,
+				8BFD638C2B57B4CE001B93C6 /* AnyTableViewCell.swift in Sources */,
 				8BFD63762B56D1AE001B93C6 /* BeerRandomViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/NetWorkProject.xcodeproj/project.pbxproj
+++ b/NetWorkProject.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		8BFD63962B57B949001B93C6 /* Papago.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFD63952B57B949001B93C6 /* Papago.swift */; };
 		8BFD63992B57CE05001B93C6 /* Enumeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFD63982B57CE05001B93C6 /* Enumeration.swift */; };
 		8BFD639E2B57D413001B93C6 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = 8BFD639D2B57D413001B93C6 /* .gitignore */; };
+		8BFD63A12B57D52D001B93C6 /* APIKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFD63A02B57D52D001B93C6 /* APIKey.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -58,6 +59,7 @@
 		8BFD63952B57B949001B93C6 /* Papago.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Papago.swift; sourceTree = "<group>"; };
 		8BFD63982B57CE05001B93C6 /* Enumeration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enumeration.swift; sourceTree = "<group>"; };
 		8BFD639D2B57D413001B93C6 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
+		8BFD63A02B57D52D001B93C6 /* APIKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKey.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,6 +95,7 @@
 		8BFD634D2B5673B1001B93C6 /* NetWorkProject */ = {
 			isa = PBXGroup;
 			children = (
+				8BFD639F2B57D4FD001B93C6 /* Resource */,
 				8BFD638E2B57B853001B93C6 /* PapagoAPI */,
 				8BFD63722B56D179001B93C6 /* BeerAPI */,
 				8BFD636F2B56BBFD001B93C6 /* Extension */,
@@ -157,6 +160,14 @@
 				8BFD63932B57B8B8001B93C6 /* PapagoMainViewController.swift */,
 			);
 			path = PapagoAPI;
+			sourceTree = "<group>";
+		};
+		8BFD639F2B57D4FD001B93C6 /* Resource */ = {
+			isa = PBXGroup;
+			children = (
+				8BFD63A02B57D52D001B93C6 /* APIKey.swift */,
+			);
+			path = Resource;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -252,6 +263,7 @@
 				8BFD634F2B5673B1001B93C6 /* AppDelegate.swift in Sources */,
 				8BFD63512B5673B1001B93C6 /* SceneDelegate.swift in Sources */,
 				8BFD637A2B56D73C001B93C6 /* Beer.swift in Sources */,
+				8BFD63A12B57D52D001B93C6 /* APIKey.swift in Sources */,
 				8BFD63712B56BC08001B93C6 /* DateFormatter+Extension.swift in Sources */,
 				8BFD63992B57CE05001B93C6 /* Enumeration.swift in Sources */,
 				8BFD63962B57B949001B93C6 /* Papago.swift in Sources */,

--- a/NetWorkProject.xcodeproj/xcuserdata/namhyeonjeong.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/NetWorkProject.xcodeproj/xcuserdata/namhyeonjeong.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "1A688892-18AD-4F8E-A916-92BD1A27B2A4"
+   type = "1"
+   version = "2.0">
+</Bucket>

--- a/NetWorkProject/APIManager.swift
+++ b/NetWorkProject/APIManager.swift
@@ -65,3 +65,24 @@ extension APIManager {
         }
     }
 }
+
+// 파파고 번역 APIManager
+extension APIManager {
+    func papagoRequest(bodyData: Parameters, completionHandler: @escaping (Result) -> Void) {
+        
+        APIManager.url = "https://openapi.naver.com/v1/papago/n2mt"
+        
+        AF.request(APIManager.url, method: .post, parameters: bodyData).responseDecodable(of: Message.self) { response in
+            switch response.result {
+            case .success(let success):
+                
+                print(success)
+                completionHandler(success.result)
+                
+            case .failure(let failure):
+                print("오류 : \(failure)")
+            }
+        }
+        
+    }
+}

--- a/NetWorkProject/APIManager.swift
+++ b/NetWorkProject/APIManager.swift
@@ -68,11 +68,11 @@ extension APIManager {
 
 // 파파고 번역 APIManager
 extension APIManager {
-    func papagoRequest(bodyData: Parameters, completionHandler: @escaping (Result) -> Void) {
+    func papagoRequest(headerData: HTTPHeaders, bodyData: Parameters, completionHandler: @escaping (Result) -> Void) {
         
         APIManager.url = "https://openapi.naver.com/v1/papago/n2mt"
         
-        AF.request(APIManager.url, method: .post, parameters: bodyData).responseDecodable(of: Message.self) { response in
+        AF.request(APIManager.url, method: .post, parameters: bodyData, headers: headerData).responseDecodable(of: Message.self) { response in
             switch response.result {
             case .success(let success):
                 

--- a/NetWorkProject/APIManager.swift
+++ b/NetWorkProject/APIManager.swift
@@ -68,16 +68,16 @@ extension APIManager {
 
 // 파파고 번역 APIManager
 extension APIManager {
-    func papagoRequest(headerData: HTTPHeaders, bodyData: Parameters, completionHandler: @escaping (Result) -> Void) {
+    func papagoRequest(headerData: HTTPHeaders, bodyData: Parameters, completionHandler: @escaping (String) -> Void) {
         
         APIManager.url = "https://openapi.naver.com/v1/papago/n2mt"
         
-        AF.request(APIManager.url, method: .post, parameters: bodyData, headers: headerData).responseDecodable(of: Message.self) { response in
+        AF.request(APIManager.url, method: .post, parameters: bodyData, headers: headerData).responseDecodable(of: Papago.self) { response in
             switch response.result {
             case .success(let success):
                 
                 print(success)
-                completionHandler(success.result)
+                completionHandler(success.message.result.translatedText)
                 
             case .failure(let failure):
                 print("오류 : \(failure)")

--- a/NetWorkProject/AnyTableViewCell.swift
+++ b/NetWorkProject/AnyTableViewCell.swift
@@ -1,0 +1,23 @@
+//
+//  AnyTableViewCell.swift
+//  NetWorkProject
+//
+//  Created by 남현정 on 2024/01/17.
+//
+
+import UIKit
+
+class AnyTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+    
+}

--- a/NetWorkProject/AnyTableViewCell.xib
+++ b/NetWorkProject/AnyTableViewCell.xib
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="AnyTableViewCell" customModule="NetWorkProject" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <point key="canvasLocation" x="17" y="21"/>
+        </tableViewCell>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="meu-XV-6gW">
+            <rect key="frame" x="0.0" y="0.0" width="393" height="44"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="meu-XV-6gW" id="hbO-AF-PU9">
+                <rect key="frame" x="0.0" y="0.0" width="393" height="44"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <point key="canvasLocation" x="-59" y="131"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/NetWorkProject/Base.lproj/Main.storyboard
+++ b/NetWorkProject/Base.lproj/Main.storyboard
@@ -58,6 +58,9 @@
                                         <rect key="frame" x="0.0" y="0.0" width="82.666666666666671" height="60"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title=""/>
+                                        <connections>
+                                            <action selector="languageButtonClicked:" destination="xu9-YZ-ky1" eventType="touchUpInside" id="mZf-uG-NSb"/>
+                                        </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Oo2-bU-JFK">
                                         <rect key="frame" x="107.66666666666666" y="0.0" width="60" height="60"/>
@@ -75,6 +78,9 @@
                                         <rect key="frame" x="192.66666666666666" y="0.0" width="82.333333333333343" height="60"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title=""/>
+                                        <connections>
+                                            <action selector="languageButtonClicked:" destination="xu9-YZ-ky1" eventType="touchUpInside" id="uk7-Wh-ePd"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <constraints>
@@ -113,6 +119,46 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="hnl-B1-pp0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1866.4122137404579" y="290.84507042253523"/>
+        </scene>
+        <!--Language View Controller-->
+        <scene sceneID="djR-E7-4Us">
+            <objects>
+                <viewController storyboardIdentifier="LanguageViewController" id="UhF-GJ-Bdv" customClass="LanguageViewController" customModule="NetWorkProject" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="4RU-zI-VNf">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="OCF-GC-CsT">
+                                <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="languageTableViewCell" id="VLJ-La-mbB">
+                                        <rect key="frame" x="0.0" y="50" width="393" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="VLJ-La-mbB" id="K7b-lf-7cT">
+                                            <rect key="frame" x="0.0" y="0.0" width="393" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="lzq-2y-Wfm"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="lzq-2y-Wfm" firstAttribute="trailing" secondItem="OCF-GC-CsT" secondAttribute="trailing" id="7EX-GE-Fgd"/>
+                            <constraint firstItem="OCF-GC-CsT" firstAttribute="top" secondItem="lzq-2y-Wfm" secondAttribute="top" id="KAq-g4-fbn"/>
+                            <constraint firstItem="OCF-GC-CsT" firstAttribute="leading" secondItem="lzq-2y-Wfm" secondAttribute="leading" id="LBs-T8-wJA"/>
+                            <constraint firstItem="lzq-2y-Wfm" firstAttribute="bottom" secondItem="OCF-GC-CsT" secondAttribute="bottom" id="neN-MO-nqk"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="languageTableView" destination="OCF-GC-CsT" id="SnH-Hp-GF2"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Uax-r0-bXE" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2749" y="291"/>
         </scene>
         <!--Beer-->
         <scene sceneID="bKF-is-bEM">

--- a/NetWorkProject/Base.lproj/Main.storyboard
+++ b/NetWorkProject/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hXi-NM-bXB">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
@@ -8,24 +8,143 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Item-->
-        <scene sceneID="tne-QT-ifu">
+        <!--Lottery-->
+        <scene sceneID="4lL-s3-YXR">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="BeerRandomViewController" customModule="NetWorkProject" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                <viewControllerPlaceholder storyboardName="Lottery" id="LMv-Jy-1Ik" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yn4-uH-pxw" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1574" y="-150"/>
+        </scene>
+        <!--Papago Main View Controller-->
+        <scene sceneID="kYu-36-BZM">
+            <objects>
+                <viewController id="xu9-YZ-ky1" customClass="PapagoMainViewController" customModule="NetWorkProject" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="6jG-xK-b74">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Ts1-gq-Kg0">
+                                <rect key="frame" x="20" y="223" width="353" height="335"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tG0-jQ-Soh">
+                                <rect key="frame" x="20" y="578" width="353" height="50"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="vYD-4r-75P"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                <connections>
+                                    <action selector="translateButtonClicked:" destination="xu9-YZ-ky1" eventType="touchUpInside" id="DnX-Xj-ISt"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pQl-mk-m2b">
+                                <rect key="frame" x="20" y="648" width="353" height="150"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="150" id="gaz-mS-pn7"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="OEo-7p-ZDc">
+                                <rect key="frame" x="59" y="143" width="275" height="60"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hFg-bg-khj">
+                                        <rect key="frame" x="0.0" y="0.0" width="82.666666666666671" height="60"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title=""/>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Oo2-bU-JFK">
+                                        <rect key="frame" x="107.66666666666666" y="0.0" width="60" height="60"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="60" id="Med-fo-UXJ"/>
+                                            <constraint firstAttribute="width" secondItem="Oo2-bU-JFK" secondAttribute="height" multiplier="1:1" id="OBf-xj-ZeK"/>
+                                        </constraints>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title=""/>
+                                        <connections>
+                                            <action selector="changeLanButtonClicked:" destination="xu9-YZ-ky1" eventType="touchUpInside" id="qcG-2C-NLt"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bKn-nn-0ee">
+                                        <rect key="frame" x="192.66666666666666" y="0.0" width="82.333333333333343" height="60"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title=""/>
+                                    </button>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="bKn-nn-0ee" firstAttribute="width" secondItem="hFg-bg-khj" secondAttribute="width" id="eCM-1o-KZN"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="IOb-Eh-56b"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="OEo-7p-ZDc" firstAttribute="top" secondItem="IOb-Eh-56b" secondAttribute="top" constant="40" id="724-AH-Qf2"/>
+                            <constraint firstItem="Ts1-gq-Kg0" firstAttribute="top" secondItem="OEo-7p-ZDc" secondAttribute="bottom" constant="20" id="FHq-gU-v4V"/>
+                            <constraint firstItem="IOb-Eh-56b" firstAttribute="bottom" secondItem="pQl-mk-m2b" secondAttribute="bottom" constant="20" id="NON-ue-Zxb"/>
+                            <constraint firstItem="pQl-mk-m2b" firstAttribute="leading" secondItem="IOb-Eh-56b" secondAttribute="leading" constant="20" id="QyP-fG-C6v"/>
+                            <constraint firstItem="IOb-Eh-56b" firstAttribute="trailing" secondItem="Ts1-gq-Kg0" secondAttribute="trailing" constant="20" id="Tac-3J-mOb"/>
+                            <constraint firstItem="pQl-mk-m2b" firstAttribute="top" secondItem="tG0-jQ-Soh" secondAttribute="bottom" constant="20" id="YTT-7h-poK"/>
+                            <constraint firstItem="OEo-7p-ZDc" firstAttribute="width" secondItem="6jG-xK-b74" secondAttribute="width" multiplier="0.7" id="ebP-u4-qom"/>
+                            <constraint firstItem="tG0-jQ-Soh" firstAttribute="top" secondItem="Ts1-gq-Kg0" secondAttribute="bottom" constant="20" id="f7N-Cp-rFd"/>
+                            <constraint firstItem="Ts1-gq-Kg0" firstAttribute="leading" secondItem="IOb-Eh-56b" secondAttribute="leading" constant="20" id="fL2-eH-5xV"/>
+                            <constraint firstItem="IOb-Eh-56b" firstAttribute="trailing" secondItem="pQl-mk-m2b" secondAttribute="trailing" constant="20" id="rmG-QL-78f"/>
+                            <constraint firstItem="OEo-7p-ZDc" firstAttribute="centerX" secondItem="6jG-xK-b74" secondAttribute="centerX" id="rzQ-gm-W87"/>
+                            <constraint firstItem="tG0-jQ-Soh" firstAttribute="leading" secondItem="IOb-Eh-56b" secondAttribute="leading" constant="20" id="tdB-nk-BiB"/>
+                            <constraint firstItem="IOb-Eh-56b" firstAttribute="trailing" secondItem="tG0-jQ-Soh" secondAttribute="trailing" constant="20" id="ugJ-fO-fLx"/>
+                        </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Item" id="x9J-UW-ZNW"/>
+                    <navigationItem key="navigationItem" id="Hnd-d8-Btd"/>
+                    <connections>
+                        <outlet property="changeLanButton" destination="Oo2-bU-JFK" id="Ww8-8M-qn9"/>
+                        <outlet property="leftLanguageButton" destination="hFg-bg-khj" id="JRm-Ct-pd5"/>
+                        <outlet property="rightLanguageButton" destination="bKn-nn-0ee" id="G3b-hx-dtN"/>
+                        <outlet property="textView" destination="Ts1-gq-Kg0" id="6gO-CZ-Ykt"/>
+                        <outlet property="translateButton" destination="tG0-jQ-Soh" id="IjN-Kr-mti"/>
+                        <outlet property="translateLabel" destination="pQl-mk-m2b" id="37l-7v-vXk"/>
+                    </connections>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="hnl-B1-pp0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="932.06106870229007" y="-2.1126760563380285"/>
+            <point key="canvasLocation" x="1866.4122137404579" y="290.84507042253523"/>
+        </scene>
+        <!--Beer-->
+        <scene sceneID="bKF-is-bEM">
+            <objects>
+                <viewControllerPlaceholder storyboardName="Beer" id="SXr-aS-JX0" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="kXs-lp-AUh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1560" y="-220"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="Ong-sK-EpP">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="hXi-NM-bXB" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Z3g-VI-lOM">
+                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="xu9-YZ-ky1" kind="relationship" relationship="rootViewController" id="l3S-ZM-GqT"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="8r0-Ef-Sby" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="939.69465648854953" y="290.84507042253523"/>
         </scene>
     </scenes>
     <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/NetWorkProject/BeerAPI/Beer.storyboard
+++ b/NetWorkProject/BeerAPI/Beer.storyboard
@@ -18,7 +18,7 @@
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Beer" selectedImage="list.clipboard.fill" catalog="system" id="vPZ-DX-HvH"/>
+                    <tabBarItem key="tabBarItem" title="Beer" image="list.clipboard.fill" catalog="system" selectedImage="list.clipboard.fill" id="vPZ-DX-HvH"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -92,7 +92,7 @@
                             <constraint firstItem="I7F-7n-ghW" firstAttribute="width" secondItem="Pt0-Ch-A00" secondAttribute="width" multiplier="0.6" id="zlB-zW-Gld"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="recommand" selectedImage="waterbottle.fill" catalog="system" id="8r5-rE-m9e"/>
+                    <tabBarItem key="tabBarItem" title="recommand" image="waterbottle.fill" catalog="system" id="8r5-rE-m9e"/>
                     <connections>
                         <outlet property="beerDescriptionLabel" destination="I37-EU-gf1" id="gBQ-kA-UPS"/>
                         <outlet property="beerImageView" destination="I7F-7n-ghW" id="c2C-uB-cho"/>
@@ -110,6 +110,7 @@
                 <tabBarController automaticallyAdjustsScrollViewInsets="NO" id="dWy-W5-ahA" sceneMemberID="viewController">
                     <toolbarItems/>
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="3Ch-0d-Sdb">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>

--- a/NetWorkProject/Enumeration.swift
+++ b/NetWorkProject/Enumeration.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum Language: String {
+enum Language: String, CaseIterable {
     case 한국어 = "ko"
     case 영어 = "en"
     case 일본어 = "ja"

--- a/NetWorkProject/Enumeration.swift
+++ b/NetWorkProject/Enumeration.swift
@@ -1,0 +1,31 @@
+//
+//  Enumeration.swift
+//  NetWorkProject
+//
+//  Created by 남현정 on 2024/01/17.
+//
+
+import Foundation
+
+enum Language: String {
+    case 한국어 = "ko"
+    case 영어 = "en"
+    case 일본어 = "ja"
+    case 중국어간체 = "zh-CN"
+    case 중국어번체 = "zh-TW"
+    case 베트남어 = "vi"
+    case 인도네시아어 = "id"
+    case 태국어 = "th"
+    case 독일어 = "de"
+    case 러시아어 = "ru"
+    case 스페인어 = "es"
+    case 이탈리아어 = "it"
+    case 프랑스어 = "fr"
+    
+    func languageString() -> String {
+        return String(describing: self) // 우와!!!
+    }
+    
+}
+
+

--- a/NetWorkProject/Info.plist
+++ b/NetWorkProject/Info.plist
@@ -16,7 +16,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>Beer</string>
+					<string>Main</string>
 				</dict>
 			</array>
 		</dict>

--- a/NetWorkProject/Model/Papago.swift
+++ b/NetWorkProject/Model/Papago.swift
@@ -6,6 +6,10 @@
 //
 
 import Foundation
+// Papago 뺴먹지 말기!
+struct Papago: Codable {
+    let message: Message
+}
 
 struct Message: Codable {
     let result: Result

--- a/NetWorkProject/Model/Papago.swift
+++ b/NetWorkProject/Model/Papago.swift
@@ -1,0 +1,18 @@
+//
+//  Papago.swift
+//  NetWorkProject
+//
+//  Created by 남현정 on 2024/01/17.
+//
+
+import Foundation
+
+struct Message: Codable {
+    let result: Result
+}
+
+struct Result: Codable {
+    let srcLangType: String
+    let tarLangType: String
+    let translatedText: String
+}

--- a/NetWorkProject/PapagoAPI/LanguageViewController.swift
+++ b/NetWorkProject/PapagoAPI/LanguageViewController.swift
@@ -1,0 +1,29 @@
+//
+//  LanguageViewController.swift
+//  NetWorkProject
+//
+//  Created by 남현정 on 2024/01/17.
+//
+
+import UIKit
+
+class LanguageViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/NetWorkProject/PapagoAPI/LanguageViewController.swift
+++ b/NetWorkProject/PapagoAPI/LanguageViewController.swift
@@ -9,21 +9,44 @@ import UIKit
 
 class LanguageViewController: UIViewController {
 
+    @IBOutlet weak var languageTableView: UITableView!
+    
+    /// 언어 목록 ["ko" : "한국어"] 식으로 저장
+    var languageDictionary: [String: String] = [:]
+    
+    var selectedLanguage: String = ""
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        for lan in Language.allCases {
+            languageDictionary[lan.rawValue] = String(describing: lan)
+        }
+        configureView()
+    }
+
+    func configureView() {
+        languageTableView.delegate = self
+        languageTableView.dataSource = self
+
+    }
+}
+
+extension LanguageViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return Language.allCases.count
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = languageTableView.dequeueReusableCell(withIdentifier: "languageTableViewCell")!
+        let rawValue = Language.allCases[indexPath.row].rawValue
+        if rawValue == selectedLanguage {
+            cell.backgroundColor = .green
+        } else {
+            cell.backgroundColor = .clear
+        }
+        cell.textLabel?.text = languageDictionary[rawValue]
+        return cell
     }
-    */
-
+  
 }

--- a/NetWorkProject/PapagoAPI/PapagoMainViewController.swift
+++ b/NetWorkProject/PapagoAPI/PapagoMainViewController.swift
@@ -27,8 +27,18 @@ class PapagoMainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         settingView()
+    }
+    
+    @IBAction func languageButtonClicked(_ sender: UIButton) {
+        let vc = storyboard?.instantiateViewController(withIdentifier: "LanguageViewController") as! LanguageViewController
         
-        
+        if sender == leftLanguageButton {
+            vc.selectedLanguage = leftLanguage.rawValue
+        } else {
+            vc.selectedLanguage = rightLanguage.rawValue
+        }
+        // 그냥 일단 버튼만 넘어가도록
+        navigationController?.pushViewController(vc, animated: true)
     }
     
     @IBAction func changeLanButtonClicked(_ sender: UIButton) {

--- a/NetWorkProject/PapagoAPI/PapagoMainViewController.swift
+++ b/NetWorkProject/PapagoAPI/PapagoMainViewController.swift
@@ -37,7 +37,12 @@ class PapagoMainViewController: UIViewController {
         leftLanguage = rightLanguage
         rightLanguage = tempLan
         
-        settingButtonLanguageTitle(left: leftLanguage, right: rightLanguage) // 버튼다시 설정
+        // 버튼다시 설정
+        settingButtonLanguageTitle(left: leftLanguage, right: rightLanguage)
+        
+        // textview와 label 초기화
+        textView.text = ""
+        translateLabel.text = ""
         
     }
     // 번역 버튼 눌렀을 때
@@ -62,8 +67,8 @@ class PapagoMainViewController: UIViewController {
                                       "target": target,
                                       "text": textView.text!]
         
-        apiManager.papagoRequest(headerData: headers, bodyData: parameters) { result in
-            self.translateLabel.text = result.translatedText // 번역한 문장 띄우기
+        apiManager.papagoRequest(headerData: headers, bodyData: parameters) { text in
+            self.translateLabel.text = text // 번역한 문장 띄우기
             
         }/*한국어*/
     }

--- a/NetWorkProject/PapagoAPI/PapagoMainViewController.swift
+++ b/NetWorkProject/PapagoAPI/PapagoMainViewController.swift
@@ -55,14 +55,14 @@ class PapagoMainViewController: UIViewController {
             return
         }
         */
-//        let headers: HTTPHeaders = ["X-Naver-Client-Id": APIKey.clientID,
-//                                    "X-Naver-Client-Secret": APIKey.clientSecret]
+        let headers: HTTPHeaders = ["X-Naver-Client-Id": APIKey.clientID,
+                                    "X-Naver-Client-Secret": APIKey.clientSecret]
         
         let parameters: Parameters = ["source": source,
                                       "target": target,
                                       "text": textView.text!]
         
-        apiManager.papagoRequest(bodyData: parameters) { result in
+        apiManager.papagoRequest(headerData: headers, bodyData: parameters) { result in
             self.translateLabel.text = result.translatedText // 번역한 문장 띄우기
             
         }/*한국어*/

--- a/NetWorkProject/PapagoAPI/PapagoMainViewController.swift
+++ b/NetWorkProject/PapagoAPI/PapagoMainViewController.swift
@@ -1,0 +1,113 @@
+//
+//  PapagoMainViewController.swift
+//  NetWorkProject
+//
+//  Created by 남현정 on 2024/01/17.
+//
+
+import UIKit
+import Alamofire
+
+class PapagoMainViewController: UIViewController {
+
+    @IBOutlet weak var leftLanguageButton: UIButton!
+    @IBOutlet weak var rightLanguageButton: UIButton!
+    
+    @IBOutlet weak var changeLanButton: UIButton!
+    @IBOutlet weak var translateButton: UIButton!
+    
+    @IBOutlet weak var textView: UITextView!
+    @IBOutlet weak var translateLabel: UILabel!
+    
+    // 맨 처음 세팅은 한국어 -> 영어 번역
+    var leftLanguage = Language.한국어
+    var rightLanguage = Language.영어
+    
+    let apiManager = APIManager()
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        settingView()
+        
+        
+    }
+    
+    @IBAction func changeLanButtonClicked(_ sender: UIButton) {
+        // 왼쪽 오른쪽 언어 바꾸기
+        let tempLan = leftLanguage
+        leftLanguage = rightLanguage
+        rightLanguage = tempLan
+        
+        settingButtonLanguageTitle(left: leftLanguage, right: rightLanguage) // 버튼다시 설정
+        
+    }
+    // 번역 버튼 눌렀을 때
+    @IBAction func translateButtonClicked(_ sender: UIButton) {
+        let source = leftLanguage.rawValue
+        let target = rightLanguage.rawValue
+        // 공백 : whitespace추후 고려....후..
+        if textView.text! == "" {
+            translateLabel.text = "번역할 문장이나 단어를 입력해주세요.."
+            return
+        }
+        /*
+        guard let source, let target else {
+            print("source, target중 nil이 있습니다!")
+            return
+        }
+        */
+//        let headers: HTTPHeaders = ["X-Naver-Client-Id": APIKey.clientID,
+//                                    "X-Naver-Client-Secret": APIKey.clientSecret]
+        
+        let parameters: Parameters = ["source": source,
+                                      "target": target,
+                                      "text": textView.text!]
+        
+        apiManager.papagoRequest(bodyData: parameters) { result in
+            self.translateLabel.text = result.translatedText // 번역한 문장 띄우기
+            
+        }/*한국어*/
+    }
+    
+    /// 언어에 따라 버튼의 title을 설정하는 함수
+    func settingButtonLanguageTitle(left: Language, right: Language) {
+        leftLanguageButton.setTitle(left.languageString(), for: .normal)
+        rightLanguageButton.setTitle(right.languageString(), for: .normal)
+    }
+    
+//    function configureView() {
+//        
+//    }
+    
+}
+
+extension PapagoMainViewController {
+    // UI
+    func settingView() {
+        
+        navigationItem.title = "Papago"
+        
+        settingButtonLanguageTitle(left: Language.한국어, right: Language.영어)
+        
+        leftLanguageButton.layer.cornerRadius = 10
+        leftLanguageButton.layer.borderWidth = 1
+        leftLanguageButton.layer.borderColor = UIColor.systemBlue.cgColor
+        
+        rightLanguageButton.layer.cornerRadius = 10
+        rightLanguageButton.layer.borderWidth = 1
+        rightLanguageButton.layer.borderColor = UIColor.systemBlue.cgColor
+        
+        changeLanButton.layer.cornerRadius = 10
+        changeLanButton.backgroundColor = .systemBlue
+        changeLanButton.setImage(UIImage(systemName: "arrow.right.arrow.left.circle"), for: .normal)
+        changeLanButton.tintColor = .white
+        
+        translateButton.setTitleColor(.white, for: .normal)
+        translateButton.setTitle("번역하기", for: .normal)
+        translateButton.backgroundColor = .systemBlue
+        translateButton.layer.cornerRadius = 10
+        translateButton.clipsToBounds = true
+        
+        translateLabel.numberOfLines = 0
+    }
+    
+}

--- a/NetWorkProject/Resource/APIKey.swift
+++ b/NetWorkProject/Resource/APIKey.swift
@@ -1,0 +1,13 @@
+//
+//  APIKey.swift
+//  NetWorkProject
+//
+//  Created by 남현정 on 2024/01/17.
+//
+
+import Foundation
+
+enum APIKey {
+    static let clientID = "xS4P03sGWh6n0zgYDqjN"
+    static let clientSecret = "25rXYK5KGU"
+}


### PR DESCRIPTION
## 🚀관련 이슈
- close #7 

## 💎작업 내용
- 

## 📸 스크린샷
<img  width="30%" src="https://github.com/nhyeonjeong/NetWorkProject/assets/102401977/6d64cda9-d664-4b77-9987-6cd41d3e1241"/>


## ⭐️참고 사항
- 테이블뷰에서 선태한 언어를 이전 화면으로 넘겨주는 부분은 아직 구현 x